### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,7 @@
 name: Validate ACS Examples
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   validate-examples:
     name: Validate example projects


### PR DESCRIPTION
Potential fix for [https://github.com/jackby03/agentic-collaboration-standard/security/code-scanning/5](https://github.com/jackby03/agentic-collaboration-standard/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block for the workflow (or each job) that grants only the minimal required scopes for the GITHUB_TOKEN. Since these jobs only need to read the repository contents (for `actions/checkout` and running tests), `contents: read` is sufficient and recommended.

The best way to fix this without changing existing functionality is to add a single root-level `permissions` block applying to all jobs in `.github/workflows/validate.yml`. This keeps the file simple and ensures all three jobs inherit the same minimal permissions. Concretely, you should insert:

```yaml
permissions:
  contents: read
```

near the top of the workflow, at the same indentation as `name:` and `on:`. For example, add it after line 2 (`on: [push, pull_request]`) and before `jobs:` on line 3. No additional methods, imports, or definitions are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
