### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-vsce.yml
+++ b/.github/workflows/publish-vsce.yml
@@ -7,6 +7,8 @@ jobs:
   publish:
     name: Publish acs-vscode
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment: vsce-publish
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/jackby03/agentic-collaboration-standard/security/code-scanning/2](https://github.com/jackby03/agentic-collaboration-standard/security/code-scanning/2)

In general, the fix is to explicitly specify a `permissions` block for the GITHUB_TOKEN, either at the workflow root (applies to all jobs) or for the specific job, and restrict it to the least privileges needed. This workflow uses `actions/checkout` (which only needs `contents: read`), `actions/setup-node`, installs dependencies, builds, and publishes using an external PAT (`secrets.VSCE_PAT`). It does not need to push commits, manage releases, or modify issues/PRs via GITHUB_TOKEN, so `contents: read` is sufficient.

The best minimal change without altering behavior is to add a `permissions` block at the job level under `publish:` so that only this job is affected, and set `contents: read`. No additional scopes such as `packages` or `id-token` are obviously required from the snippet provided. Concretely, in `.github/workflows/publish-vsce.yml`, between lines 9 and 10 (after `runs-on: ubuntu-latest`), add:

```yaml
    permissions:
      contents: read
```

This keeps the job functional while ensuring the implicit GITHUB_TOKEN cannot perform write operations on the repository. No imports or other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
