### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,6 +8,8 @@ jobs:
     name: Publish agentic-standard CLI
     runs-on: ubuntu-latest
     environment: npm-publish
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/jackby03/agentic-collaboration-standard/security/code-scanning/1](https://github.com/jackby03/agentic-collaboration-standard/security/code-scanning/1)

In general, to fix this class of issue you add an explicit `permissions` block either at the top level of the workflow (applies to all jobs) or under the specific job that runs. You then restrict `GITHUB_TOKEN` scopes to the minimum required by the steps (for this workflow, just reading repository contents).

For this workflow, the simplest, non‑disruptive fix is to add a job‑level `permissions` block under `jobs.publish` specifying `contents: read`. None of the steps require GitHub write access; they only need to clone the repo (`actions/checkout`) and then interact with npm using `NODE_AUTH_TOKEN`. So we will edit `.github/workflows/publish-npm.yml` and, directly under `publish:` (or under `runs-on:`/`environment:`), add:

```yaml
permissions:
  contents: read
```

No imports or additional methods are required, as this is a pure YAML configuration change for GitHub Actions. Functionality of the workflow remains identical while the `GITHUB_TOKEN` is now constrained.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
