### PR TITLE
feat(site): Next.js site for Vercel

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+npm-debug.log*
+*.log

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,20 @@
+# ACS site (Vercel prototype)
+
+Quick prototype of a Next.js site intended for deployment to Vercel.
+
+Local development
+
+```bash
+cd site
+npm install
+npm run dev
+```
+
+Deployment notes
+
+- Create a new project in Vercel and link this repository.
+- Set the Project Root to `site/` (in Vercel Project Settings) so Vercel builds the Next app.
+- Build command: `npm run build`, Output Directory: (leave default). Vercel will detect Next.js automatically.
+- Enable Vercel Analytics in the project dashboard to collect analytics; the site already includes `@vercel/analytics` and renders `<Analytics />` in `_app.js`.
+
+Optional: Environment-specific settings can be configured in the Vercel dashboard.

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "acs-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@vercel/analytics": "latest"
+  }
+}

--- a/site/pages/_app.js
+++ b/site/pages/_app.js
@@ -1,0 +1,10 @@
+import { Analytics } from '@vercel/analytics/react'
+
+export default function App({ Component, pageProps }) {
+  return (
+    <>
+      <Component {...pageProps} />
+      <Analytics />
+    </>
+  )
+}

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -1,0 +1,14 @@
+export default function Home() {
+  return (
+    <main style={{fontFamily: 'system-ui, sans-serif', padding: 40}}>
+      <h1>Agentic Collaboration Standard</h1>
+      <p>
+        This is a minimal Next.js prototype site for publishing the ACS docs on Vercel.
+      </p>
+      <p>
+        Deployment notes are included in <strong>site/README.md</strong>.
+      </p>
+      <a href="/docs/">View docs</a>
+    </main>
+  )
+}


### PR DESCRIPTION
# ACS site (Vercel prototype)

Quick prototype of a Next.js site intended for deployment to Vercel.

Local development

```bash
cd site
npm install
npm run dev
```

Deployment notes

- Create a new project in Vercel and link this repository.
- Set the Project Root to `site/` (in Vercel Project Settings) so Vercel builds the Next app.
- Build command: `npm run build`, Output Directory: (leave default). Vercel will detect Next.js automatically.
- Enable Vercel Analytics in the project dashboard to collect analytics; the site already includes `@vercel/analytics` and renders `<Analytics />` in `_app.js`.

Optional: Environment-specific settings can be configured in the Vercel dashboard.
